### PR TITLE
fix: update name to match plugin naming schema

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import setSurchargesOnCart from "./util/setSurchargesOnCart.js";
 export default async function register(app) {
   await app.registerPlugin({
     label: "Surcharges",
-    name: "api-plugin-surcharges",
+    name: "surcharges",
     version: pkg.version,
     collections: {
       Surcharges: {


### PR DESCRIPTION
Update the name of the registered plugins to remove `api-plugin` and match all other plugin names. If desired, there can be an accompanying PR in Reaction to update this package to `1.0.1`.