### PR TITLE
Add offset for surcharges query

### DIFF
--- a/src/schemas/schema.graphql
+++ b/src/schemas/schema.graphql
@@ -327,6 +327,9 @@ extend type Query {
     "Return at most this many results. This parameter may be used with the `before` parameter."
     last: ConnectionLimitInt,
 
+    "Return only results that come after the Nth result. This parameter may be used with the `first` parameter."
+    offset: Int,
+
     "Return results sorted in this order"
     sortOrder: SortOrder = desc,
 


### PR DESCRIPTION
Signed-off-by: trojanh <rajan.tiwari@kiprosh.com>

Issue: https://github.com/reactioncommerce/reaction/issues/6252
Impact: **minor**
Type: **bugfix**

## Issue
Missing offset params for pagination for surcharges query
