### PR TITLE
chore: using context to call mutation functions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     dependencies:
       pre:
@@ -20,7 +20,7 @@ jobs:
 
   deploy:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
 
   lint:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
 
   test-integration:
     docker:
-      - image: circleci/node:14.11.0-stretch
+      - image: circleci/node:14.18.1-stretch
       # Integration tests need MongoDB server running and accessible on port 27017
       - image: circleci/mongo:4.2.0
         command: mongod --oplogSize 128 --replSet rs0 --storageEngine=wiredTiger
@@ -67,7 +67,7 @@ jobs:
 
   lint-graphql:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout
@@ -82,7 +82,7 @@ jobs:
 
   test:
     docker:
-      - image: node:12.14.1
+      - image: node:14.18.1
 
     steps:
       - checkout

--- a/src/resolvers/Mutation/createSurcharge.js
+++ b/src/resolvers/Mutation/createSurcharge.js
@@ -1,5 +1,4 @@
 import { decodeFulfillmentMethodOpaqueId, decodeShopOpaqueId } from "../../xforms/id.js";
-import createSurchargeMutation from "../../mutations/createSurcharge.js";
 
 /**
  * @name Mutation/createSurcharge
@@ -26,7 +25,7 @@ export default async function createSurcharge(parentResult, { input }, context) 
 
   surcharge.methodIds = decodedMethodIds;
 
-  const { surcharge: insertedSurcharge } = await createSurchargeMutation(context, {
+  const { surcharge: insertedSurcharge } = await context.mutations.createSurcharge(context, {
     surcharge,
     shopId
   });

--- a/src/resolvers/Mutation/deleteSurcharge.js
+++ b/src/resolvers/Mutation/deleteSurcharge.js
@@ -1,5 +1,4 @@
 import { decodeShopOpaqueId, decodeSurchargeOpaqueId } from "../../xforms/id.js";
-import deleteSurchargeMutation from "../../mutations/deleteSurcharge.js";
 
 /**
  * @name Mutation/deleteSurcharge
@@ -20,7 +19,7 @@ export default async function deleteSurcharge(parentResult, { input }, context) 
   const shopId = decodeShopOpaqueId(opaqueShopId);
   const surchargeId = decodeSurchargeOpaqueId(opaqueSurchargeId);
 
-  const { surcharge } = await deleteSurchargeMutation(context, {
+  const { surcharge } = await context.mutations.deleteSurcharge(context, {
     surchargeId,
     shopId
   });

--- a/src/resolvers/Mutation/updateSurcharge.js
+++ b/src/resolvers/Mutation/updateSurcharge.js
@@ -1,5 +1,4 @@
 import { decodeFulfillmentMethodOpaqueId, decodeShopOpaqueId, decodeSurchargeOpaqueId } from "../../xforms/id.js";
-import updateSurchargeMutation from "../../mutations/updateSurcharge.js";
 
 /**
  * @name Mutation/updateSurcharge
@@ -28,7 +27,7 @@ export default async function updateSurcharge(parentResult, { input }, context) 
 
   surcharge.methodIds = decodedMethodIds;
 
-  const { surcharge: updatedSurcharge } = await updateSurchargeMutation(context, {
+  const { surcharge: updatedSurcharge } = await context.mutations.updateSurcharge(context, {
     surcharge,
     surchargeId,
     shopId


### PR DESCRIPTION
Resolves #10 
Impact: **minor**
Type: **chore**

## Issue
The mutation resolvers revolving around Surcharge CRUD operations don't call the mutations on the context object like context.mutations.something() but instead directly import the logic in the resolver.

## Solution
Remove wrong import and use functions directly from context object

If you're solving a UIX related issue, please attach screen-caps or gifs showing how your solution differs from the issue.

## Testing
Call createSurcharge / deleteSurcharge / updateSurcharge from graphql

